### PR TITLE
24.0821 API 엔드포인트 전면 수정 및 로그인 로직 임시 수정

### DIFF
--- a/src/components/footer/Footer.jsx
+++ b/src/components/footer/Footer.jsx
@@ -31,7 +31,7 @@ function Footer() {
     useEffect(() => {
         const fetchUserId = async () => {
             try {
-                const response = await axios.get("https://zmffjq.store/getUserId", {
+                const response = await axios.get("/api/getUserId", {
                     withCredentials: true
                 });
                 console.log(response.data);

--- a/src/components/modal/Modal_post.jsx
+++ b/src/components/modal/Modal_post.jsx
@@ -12,7 +12,7 @@ const Modal_post = ({onClose, onEdit}) => {
     const [onConfirm, setOnConfirm] = useState(() => () => {});
 
     const apiClient = axios.create({
-        baseURL: 'https://zmffjq.store', // API URL
+        baseURL: '/api', // API URL
         timeout: 10000, // 요청 타임아웃 설정 (10초)
         headers: {
             'Content-Type': 'application/json',

--- a/src/pages/community/CommunityPostDetail.jsx
+++ b/src/pages/community/CommunityPostDetail.jsx
@@ -14,7 +14,7 @@ import Modal_post_complain from '../../components/modal/Modal_post_complain.jsx'
 import Modal_comment from '../../components/modal/Modal_comment.jsx';
 
 const apiClient = axios.create({
-    baseURL: 'https://zmffjq.store',
+    baseURL: '/api',
     timeout: 10000,
     headers: {
         'Content-Type': 'application/json',

--- a/src/pages/community/CommunityPostEdit.jsx
+++ b/src/pages/community/CommunityPostEdit.jsx
@@ -7,7 +7,7 @@ import { FiX, FiCheck } from "react-icons/fi";
 import { LuImagePlus } from "react-icons/lu";
 
 const apiClient = axios.create({
-    baseURL: 'https://zmffjq.store',
+    baseURL: '/api',
     timeout: 10000,
     headers: {
         'Content-Type': 'application/json',
@@ -164,7 +164,7 @@ function CommunityPostEdit() {
     const uploadFileToS3 = async (file) => {
         try {
             const filename = encodeURIComponent(file.name);
-            const response = await axios.get(`https://zmffjq.store/presigned-url?filename=${filename}`);
+            const response = await axios.get(`/api/presigned-url?filename=${filename}`);
             const presignedUrl = response.data;
 
             await fetch(presignedUrl, {

--- a/src/pages/community/Community_Main.jsx
+++ b/src/pages/community/Community_Main.jsx
@@ -127,7 +127,7 @@ const Separator = styled.span`
 `;
 
 const apiClient = axios.create({
-    baseURL: 'https://zmffjq.store',
+    baseURL: '/api',
     headers: {
         'Content-Type': 'application/json',
     },

--- a/src/pages/community/WritePostModal.jsx
+++ b/src/pages/community/WritePostModal.jsx
@@ -137,7 +137,7 @@ function WritePostModal({ isOpen, onClose, onSubmit }) {
     const uploadFileToS3 = async (file) => {
         try {
             const filename = encodeURIComponent(file.name);
-            const response = await axios.get(`https://zmffjq.store/presigned-url?filename=${filename}`);
+            const response = await axios.get(`/api/presigned-url?filename=${filename}`);
             const presignedUrl = response.data;
 
             await fetch(presignedUrl, {
@@ -163,7 +163,7 @@ function WritePostModal({ isOpen, onClose, onSubmit }) {
                     attachment_names: attachmentNames,
                     club_name: '.' // 동아리 이름 대신 '.' 전송
                 };
-                const response = await fetch('https://zmffjq.store/board/1/posts', {
+                const response = await fetch('/api/board/1/posts', {
                     method: 'POST',
                     body: JSON.stringify(postData),
                     headers: { 'Content-Type': 'application/json' },

--- a/src/pages/community/activity/ActivityDetailPage.jsx
+++ b/src/pages/community/activity/ActivityDetailPage.jsx
@@ -27,8 +27,8 @@ function ActivityDetailPage() {
         const fetchData = async () => {
             try {
                 const [postResponse, clubsResponse] = await Promise.all([
-                    axios.get(`https://zmffjq.store/board/3/clubs/${clubId}/posts/${postId}`),
-                    axios.get('https://zmffjq.store/clubs')
+                    axios.get(`/api/board/3/clubs/${clubId}/posts/${postId}`),
+                    axios.get('/api/clubs')
                 ]);
 
                 const postData = postResponse.data;

--- a/src/pages/community/activity/ActivityPage.jsx
+++ b/src/pages/community/activity/ActivityPage.jsx
@@ -10,11 +10,11 @@ function ActivityPage() {
     useEffect(() => {
         const fetchAllClubActivities = async () => {
             try {
-                const clubsResponse = await axios.get('https://zmffjq.store/clubs');
+                const clubsResponse = await axios.get('/api/clubs');
                 const clubs = clubsResponse.data;
 
                 const activitiesPromises = clubs.map(club =>
-                    axios.get(`https://zmffjq.store/board/3/clubs/${club.clubId}/posts`)
+                    axios.get(`/api/board/3/clubs/${club.clubId}/posts`)
                 );
 
                 const activitiesResponses = await Promise.all(activitiesPromises);

--- a/src/pages/login/login.jsx
+++ b/src/pages/login/login.jsx
@@ -107,7 +107,14 @@ function Login() {
 
             const data = response.data;
 
-            if (data.message === '성공') {
+            // 24.08.21 response.status === 200이면 로그인 성공하다록 수정 (이정훈)
+            // 이 방법은 로그인 실패 시에도 로그인이 되서 추후 개선이 필요함
+            // if (data.message === '성공') {
+            //     localStorage.setItem('memberId', data.memberId);
+            //     console.log('로그인 성공, 메인 페이지로 이동합니다.');
+            //     navigate('/main');
+            // }
+            if (response.status === 200) {
                 localStorage.setItem('memberId', data.memberId);
                 console.log('로그인 성공, 메인 페이지로 이동합니다.');
                 navigate('/main');

--- a/src/pages/login/login.jsx
+++ b/src/pages/login/login.jsx
@@ -98,7 +98,7 @@ function Login() {
         formData.append('password', password);
 
         try {
-            const response = await axios.post('https://zmffjq.store/login', formData, {
+            const response = await axios.post('/api/login', formData, {
                 withCredentials: true
             });
 

--- a/src/pages/login/signup.jsx
+++ b/src/pages/login/signup.jsx
@@ -147,7 +147,7 @@ function Signup() {
             formData.append('department', department);
             formData.append('phone', phone);
 
-            const response = await fetch('https://zmffjq.store/signup', {
+            const response = await fetch('/api/signup', {
                 method: 'POST',
                 body: formData
             });

--- a/src/pages/main/ClubDetailPage.jsx
+++ b/src/pages/main/ClubDetailPage.jsx
@@ -16,7 +16,7 @@ const ClubDetailPage = () => {
     const navigate = useNavigate();
 
     const apiClient = axios.create({
-        baseURL: 'https://zmffjq.store', // .env 파일에서 API URL 가져오기
+        baseURL: '/api', // .env 파일에서 API URL 가져오기
         timeout: 10000, // 요청 타임아웃 설정 (10초)
         headers: {
             'Content-Type': 'application/json',
@@ -26,7 +26,7 @@ const ClubDetailPage = () => {
     useEffect(() => {
         const fetchUserId = async () => {
             try {
-                const response = await axios.get("https://zmffjq.store/getUserId", {
+                const response = await axios.get("/api/getUserId", {
                     withCredentials: true
                 });
                 console.log(response.data);
@@ -57,7 +57,7 @@ const ClubDetailPage = () => {
     useEffect(() => {
         const fetchClubDetails = async () => {
             try {
-                const response = await fetch(`https://zmffjq.store/clubs/${clubName}`);
+                const response = await fetch(`/api/clubs/${clubName}`);
                 if (response.ok) {
                     const data = await response.json();
                     setClub(data);
@@ -92,7 +92,7 @@ const ClubDetailPage = () => {
 
     const fetchMemberDetails = async (memberId) => {
         try {
-            const response = await axios.get(`https://zmffjq.store/members/${memberId}`);
+            const response = await axios.get(`/api/members/${memberId}`);
             if (response.data) {
                 setUserInfo(prevState => ({
                     ...prevState,
@@ -109,10 +109,10 @@ const ClubDetailPage = () => {
 
     const fetchLastActivityImage = async (clubId) => {
         try {
-            const response = await axios.get(`https://zmffjq.store/board/3/clubs/${clubId}/posts`);
+            const response = await axios.get(`/api/board/3/clubs/${clubId}/posts`);
             if (response.data && response.data.length > 0) {
                 const lastPost = response.data[0];
-                const postResponse = await axios.get(`https://zmffjq.store/board/3/clubs/${clubId}/posts/${lastPost.postId}`);
+                const postResponse = await axios.get(`/api/board/3/clubs/${clubId}/posts/${lastPost.postId}`);
                 const attachmentNames = postResponse.data.attachmentNames || [];
                 if (attachmentNames.length > 0) {
                     setLastActivityImage(attachmentNames[0]);
@@ -137,7 +137,7 @@ const ClubDetailPage = () => {
                 withCredentials: true
             };
 
-            const response = await axios.post(`https://zmffjq.store/clubs/${clubName}/applications`, {
+            const response = await axios.post(`/api/clubs/${clubName}/applications`, {
                 motivation
             }, config);
 

--- a/src/pages/main/MainPage.jsx
+++ b/src/pages/main/MainPage.jsx
@@ -132,7 +132,7 @@ function MainPage() {
 
     const fetchAllClubs = async () => {
         try {
-            const response = await axios.get("https://zmffjq.store/clubs");
+            const response = await axios.get("/api/clubs");
             setAllClubs(response.data);
             setFilteredClubs([]);
         } catch (error) {

--- a/src/pages/myclub/MyclubDetail.jsx
+++ b/src/pages/myclub/MyclubDetail.jsx
@@ -33,9 +33,9 @@ function MyclubDetail() {
             setError(null);
             try {
                 const [noticeResponse, freeboardResponse,activityResponse] = await Promise.all([
-                    axios.get(`https://zmffjq.store/clubs/${id}/board/2/posts`),
-                    axios.get(`https://zmffjq.store/clubs/${id}/board/4/posts`),
-                    axios.get(`https://zmffjq.store/board/3/clubs/${id}/posts`)
+                    axios.get(`/api/clubs/${id}/board/2/posts`),
+                    axios.get(`/api/clubs/${id}/board/4/posts`),
+                    axios.get(`/api/board/3/clubs/${id}/posts`)
                 ]);
 
                 // 공지사항
@@ -56,7 +56,7 @@ function MyclubDetail() {
                         activityResponse.data.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt))
                             .map(async (post) => {
                                 try {
-                                    const imgResponse = await axios.get(`https://zmffjq.store/board/3/clubs/${id}/posts/${post.postId}`);
+                                    const imgResponse = await axios.get(`/api/board/3/clubs/${id}/posts/${post.postId}`);
                                     const attachmentNames = imgResponse.data.attachmentNames || [];
                                     return {
                                         ...post,

--- a/src/pages/myclub/MyclubMain.jsx
+++ b/src/pages/myclub/MyclubMain.jsx
@@ -7,7 +7,7 @@ import Header_center from "../../components/header/Header_center.jsx";
 import styled from 'styled-components';
 
 const apiClient = axios.create({
-    baseURL: 'https://zmffjq.store',
+    baseURL: '/api',
     headers: {
         'Content-Type': 'application/json',
     },

--- a/src/pages/myclub/activityBoard/ActivityDetail.jsx
+++ b/src/pages/myclub/activityBoard/ActivityDetail.jsx
@@ -10,7 +10,7 @@ import Modal_post_complain from "../../../components/modal/Modal_post_complain.j
 import { FaRegThumbsUp } from "react-icons/fa6";
 
 const apiClient = axios.create({
-    baseURL: 'https://zmffjq.store',
+    baseURL: '/api',
     headers: {
         'Content-Type': 'application/json',
     },

--- a/src/pages/myclub/activityBoard/ActivityEdit.jsx
+++ b/src/pages/myclub/activityBoard/ActivityEdit.jsx
@@ -19,7 +19,7 @@ function ActivityEdit() {
     });
 
     const apiClient = axios.create({
-        baseURL: 'https://zmffjq.store',
+        baseURL: '/api',
         timeout: 10000,
         headers: {
             'Content-Type': 'application/json',

--- a/src/pages/myclub/component/PostEdit.jsx
+++ b/src/pages/myclub/component/PostEdit.jsx
@@ -18,7 +18,7 @@ function PostEdit() {
     const [onConfirm, setOnConfirm] = useState(() => () => {});
 
     const apiClient = axios.create({
-        baseURL: 'https://zmffjq.store',
+        baseURL: '/api',
         timeout: 10000,
         headers: {
             'Content-Type': 'application/json',

--- a/src/pages/myclub/component/PostWrite.jsx
+++ b/src/pages/myclub/component/PostWrite.jsx
@@ -8,7 +8,7 @@ import styled from "styled-components";
 
 function PostWrite({ boardType, apiEndpoint, navigateBackPath }) {
     const apiClient = axios.create({
-        baseURL: 'https://zmffjq.store',
+        baseURL: '/api',
         timeout: 10000,
         headers: { 'Content-Type': 'application/json' },
     });

--- a/src/pages/myclub/component/PostsList.jsx
+++ b/src/pages/myclub/component/PostsList.jsx
@@ -8,7 +8,7 @@ import axios from "axios";
 import { FaRegThumbsUp } from "react-icons/fa6";
 
 const apiClient = axios.create({
-    baseURL: 'https://zmffjq.store',
+    baseURL: '/api',
     headers: {
         'Content-Type': 'application/json',
     },

--- a/src/pages/myclub/headerHamburger/Slide.jsx
+++ b/src/pages/myclub/headerHamburger/Slide.jsx
@@ -29,7 +29,7 @@ function Slide({ clubName, clubImgUrl }) {
     const memberId = location.state?.memberId || localStorage.getItem('memberId');
 
     const apiClient = axios.create({
-        baseURL: 'https://zmffjq.store',
+        baseURL: '/api',
         timeout: 10000,
         headers: {
             'Content-Type': 'application/json',

--- a/src/pages/myclub/headerHamburger/club_manage/ClubInfoEdit.jsx
+++ b/src/pages/myclub/headerHamburger/club_manage/ClubInfoEdit.jsx
@@ -9,7 +9,7 @@ axios.defaults.withCredentials = true;
 
 function ClubInfoEdit() {
     const apiClient = axios.create({
-        baseURL: 'https://zmffjq.store',
+        baseURL: '/api',
         timeout: 10000,
     });
 

--- a/src/pages/myclub/headerHamburger/member_manage/member_info_fix/Member_info_fix.jsx
+++ b/src/pages/myclub/headerHamburger/member_manage/member_info_fix/Member_info_fix.jsx
@@ -33,7 +33,7 @@ function Member_info_fix() {
 
     // Axios 인스턴스 생성 및 설정
     const apiClient = axios.create({
-        baseURL: 'https://zmffjq.store',  // 환경 변수에서 API URL 가져오기
+        baseURL: '/api',  // 환경 변수에서 API URL 가져오기
         timeout: 10000,  // 요청 타임아웃 설정 (10초)
         headers: {
             'Content-Type': 'application/json',

--- a/src/pages/myclub/headerHamburger/member_manage/member_info_fix_list/Member_info_fix_list.jsx
+++ b/src/pages/myclub/headerHamburger/member_manage/member_info_fix_list/Member_info_fix_list.jsx
@@ -24,7 +24,7 @@ function Member_info_fix_list() {
 `;
 
     const apiClient = axios.create({
-        baseURL: 'https://zmffjq.store', // .env 파일에서 API URL 가져오기
+        baseURL: '/api', // .env 파일에서 API URL 가져오기
         timeout: 10000, // 요청 타임아웃 설정 (10초)
         headers: {
             'Content-Type': 'application/json',

--- a/src/pages/myclub/headerHamburger/member_manage/member_request/Member_request.jsx
+++ b/src/pages/myclub/headerHamburger/member_manage/member_request/Member_request.jsx
@@ -24,7 +24,7 @@ function Member_request() {
 `;
 
     const apiClient = axios.create({
-        baseURL: 'https://zmffjq.store',
+        baseURL: '/api',
         timeout: 10000,
         headers: {
             'Content-Type': 'application/json',

--- a/src/pages/myclub/headerHamburger/member_manage/member_request/Member_request_detail.jsx
+++ b/src/pages/myclub/headerHamburger/member_manage/member_request/Member_request_detail.jsx
@@ -30,7 +30,7 @@ function Member_request_detail() {
 `;
 
     const apiClient = axios.create({
-        baseURL: 'https://zmffjq.store',
+        baseURL: '/api',
         timeout: 10000,
         headers: {
             'Content-Type': 'application/json',

--- a/src/pages/myclub/hooks/usePostDetail.jsx
+++ b/src/pages/myclub/hooks/usePostDetail.jsx
@@ -4,7 +4,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import axios from "axios";
 
 const apiClient = axios.create({
-    baseURL: 'https://zmffjq.store',
+    baseURL: '/api',
     timeout: 10000,
     headers: {
         'Content-Type': 'application/json',

--- a/src/pages/mypage/create_club/Create_club.jsx
+++ b/src/pages/mypage/create_club/Create_club.jsx
@@ -26,7 +26,7 @@ function Create_club() {
 `;
 
     const apiClient = axios.create({
-        baseURL: 'https://zmffjq.store',
+        baseURL: '/api',
         timeout: 10000, // 요청 타임아웃 설정 (10초)
         headers: {
             'Content-Type': 'application/json',

--- a/src/pages/mypage/edit_info/Edit_info.jsx
+++ b/src/pages/mypage/edit_info/Edit_info.jsx
@@ -24,7 +24,7 @@ function Edit_info() {
 `;
 
     const apiClient = axios.create({
-        baseURL: 'https://zmffjq.store',
+        baseURL: '/api',
         timeout: 10000,
         headers: {
             'Content-Type': 'application/json',

--- a/src/pages/mypage/mypage_main/Mypage.jsx
+++ b/src/pages/mypage/mypage_main/Mypage.jsx
@@ -10,7 +10,7 @@ import axios from "axios";
 function Mypage() {
 
     const apiClient = axios.create({
-        baseURL: 'https://zmffjq.store', // .env 파일에서 API URL 가져오기
+        baseURL: '/api', // .env 파일에서 API URL 가져오기
         timeout: 10000, // 요청 타임아웃 설정 (10초)
         headers: {
             'Content-Type': 'application/json',

--- a/src/pages/mypage/written_post/BoardEdit.jsx
+++ b/src/pages/mypage/written_post/BoardEdit.jsx
@@ -24,7 +24,7 @@ function BoardEdit() {
     const [isModalOpen, setIsModalOpen] = useState(false);
 
     const apiClient = axios.create({
-        baseURL: 'https://zmffjq.store',
+        baseURL: '/api',
         timeout: 10000,
         headers: {
             'Content-Type': 'application/json',
@@ -49,7 +49,7 @@ function BoardEdit() {
 
     const fetchUserId = async () => {
         try {
-            const response = await axios.get("https://zmffjq.store/getUserId", {
+            const response = await axios.get("/api/getUserId", {
                 withCredentials: true,
             });
             setMemberId(response.data.message);

--- a/src/pages/mypage/written_post/Written_post.jsx
+++ b/src/pages/mypage/written_post/Written_post.jsx
@@ -117,7 +117,7 @@ function Written_post() {
     const { memberId } = useParams();
 
     const apiClient = axios.create({
-        baseURL: 'http://3.36.56.20:8080', // .env 파일에서 API URL 가져오기
+        baseURL: '/api', // .env 파일에서 API URL 가져오기
         timeout: 10000, // 요청 타임아웃 설정 (10초)
         headers: {
             'Content-Type': 'application/json',

--- a/src/pages/mypage/written_post/Written_post_detail.jsx
+++ b/src/pages/mypage/written_post/Written_post_detail.jsx
@@ -188,7 +188,7 @@ function Written_post_detail() {
     const [editedCommentContent, setEditedCommentContent] = useState('');
 
     const apiClient = axios.create({
-        baseURL: 'https://zmffjq.store', // API URL
+        baseURL: '/api', // API URL
         timeout: 10000, // 요청 타임아웃 설정 (10초)
         headers: {
             'Content-Type': 'application/json',


### PR DESCRIPTION
24.08.21 기준 마지막 PR pull 한 후에 수정한 내용입니다.
확인 후에 코맨트 및 의견 주세요! 

**1. API 엔드포인트 변경**
"https://zmffjq.store/" 를 전부 "/api"로 바꾸었습니다.

프론트에서 벡엔드로 정보를 요청하는 방식을 바꾸어 보았는데
이렇게 바꿈으로서 아이폰에서 로그인이 안되는 오류를 해결할 수 있었습니다.

**2. 로그인 성공조건을 임시적으로 바꿈**
data.message === '성공'  에서
response.status === 200  으로

data.message에 자꾸 알수없는 이유로 html이 전달되서 로그인이 안되어서 일단 임시방편으로 로그인이 가능하도록
이렇게 수정하였습니다.
기존의 코드는 삭제하지 않고 주석처리 해두었습니다.
(login,jsx) 파일에 있습니다 

**3. 로컬에서 테스트 시에 API 엔드 포인트**
벡엔드 서버 IP가 아래와 같습니다
http://43.203.195.60:8080/
/api를 저 http 주소로 바꾸어주면 될 것 같지만 
리액트를 로컬에서 돌리면서 서버에 http 요청을 하면 로그인 세션 쿠키값이 발급안됩니다. (보안 이슈)

그래서 제일 좋은 방법은 로컬에서 테스트를 하려면 
백엔드도 로컬, 프론트도 로컬에서 돌려서 테스트 하는게 제일 좋을 것 같아요.
벡엔드 프로젝트 셋팅은 git clone해서 하면 되는데 
벡엔드 프로젝트 설정에 어려움이 있으면 저한테 오시면 해결해 드리겠습니다.